### PR TITLE
Android version

### DIFF
--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -3,6 +3,6 @@
   <Page.actionBar>
     <ActionBar class="action-bar-calm" title="Status Bar Test" />
   </Page.actionBar>
-  <x:StatusBar barStyle="light" />
+    <x:StatusBar ios:barStyle="light" android:barStyle="#0097A7" />
   <WebView src="https://github.com/burkeholland/nativescript-statusbar/blob/master/README.md" />
 </Page>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
             "name": "Burke Holland",
             "email": "burkeholland@gmail.com",
             "url": "https://github.com/burkeholland"
-        }   
+        },
+        {
+            "name": "Brad Martin",
+            "email": "bradwaynemartin@gmail.com",
+            "url": "https://github.com/bradmartin"
+        }
     ],
     "license": "MIT",
     "devDependencies": {

--- a/source/statusbar-common.js
+++ b/source/statusbar-common.js
@@ -6,6 +6,7 @@ var __extends = (this && this.__extends) || function (d, b) {
 var view_1 = require("ui/core/view");
 var dependencyObservable = require("ui/core/dependency-observable");
 var proxy = require("ui/core/proxy");
+var app = require("application");
 var BARSTYLE = "barStyle", STATUSBAR = "StatusBar";
 var BarStyle;
 (function (BarStyle) {
@@ -18,7 +19,12 @@ var onBarStylePropertyChanged = function (data) {
     try {
         var statusbar_1 = data.object;
         var value = data.newValue;
-        setTimeout(function () { statusbar_1.update(BarStyle[value]); });
+        if (app.ios) {
+            setTimeout(function () { statusbar_1.update(BarStyle[value]); });
+        }
+        if (app.android) {
+            setTimeout(function () { statusbar_1.update(value); });
+        }
     }
     catch (err) {
         console.log(err);

--- a/source/statusbar-common.ts
+++ b/source/statusbar-common.ts
@@ -1,57 +1,53 @@
-import definition = require("statusbar");
-import { View } from "ui/core/view";
-import * as dependencyObservable from "ui/core/dependency-observable";
-import * as proxy from "ui/core/proxy";
-import app = require("application");
-
-let BARSTYLE = "barStyle",
-    STATUSBAR = "StatusBar";
-    
-enum BarStyle {
-    default,
-    light,
-    dark,
-    opaque
-}
-    
-let onBarStylePropertyChanged = (data: dependencyObservable.PropertyChangeData) => {
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var view_1 = require("ui/core/view");
+var dependencyObservable = require("ui/core/dependency-observable");
+var proxy = require("ui/core/proxy");
+var app = require("application");
+var BARSTYLE = "barStyle", STATUSBAR = "StatusBar";
+var BarStyle;
+(function (BarStyle) {
+    BarStyle[BarStyle["default"] = 0] = "default";
+    BarStyle[BarStyle["light"] = 1] = "light";
+    BarStyle[BarStyle["dark"] = 2] = "dark";
+    BarStyle[BarStyle["opaque"] = 3] = "opaque";
+})(BarStyle || (BarStyle = {}));
+var onBarStylePropertyChanged = function (data) {
     try {
-        let statusbar = <StatusBar>data.object;
-        let value = data.newValue;
-        
+        var statusbar_1 = data.object;
+        var value = data.newValue;
         if (app.ios) {
-            setTimeout(() => { statusbar.update(BarStyle[value]); });
+            setTimeout(function () { statusbar_1.update(BarStyle[value]); });
         }
-
         if (app.android) {
-            setTimeout(() => { statusbar.update(value); });
+            setTimeout(function () { statusbar_1.update(value); });
         }
     }
     catch (err) {
         console.log(err);
     }
-}
-
-export class StatusBar extends View implements definition.StatusBar {  
-    
-    public static  barStyleProperty = new dependencyObservable.Property(
-        BARSTYLE,
-        STATUSBAR,
-        new proxy.PropertyMetadata(undefined, dependencyObservable.PropertyMetadataSettings.None, onBarStylePropertyChanged)
-    );
-    
-    constructor(options?: definition.Options) {
-        super(options);
+};
+var StatusBar = (function (_super) {
+    __extends(StatusBar, _super);
+    function StatusBar(options) {
+        _super.call(this, options);
     }
-    
-    public update(value: string) {
-        
-    }
-    
-    get barStyle(): any {
-        return this._getValue(StatusBar.barStyleProperty);
-    }
-    set barStyle(value: any) {
-        this._setValue(StatusBar.barStyleProperty, value);
-    }
-}
+    StatusBar.prototype.update = function (value) {
+    };
+    Object.defineProperty(StatusBar.prototype, "barStyle", {
+        get: function () {
+            return this._getValue(StatusBar.barStyleProperty);
+        },
+        set: function (value) {
+            this._setValue(StatusBar.barStyleProperty, value);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    StatusBar.barStyleProperty = new dependencyObservable.Property(BARSTYLE, STATUSBAR, new proxy.PropertyMetadata(undefined, dependencyObservable.PropertyMetadataSettings.None, onBarStylePropertyChanged));
+    return StatusBar;
+})(view_1.View);
+exports.StatusBar = StatusBar;

--- a/source/statusbar-common.ts
+++ b/source/statusbar-common.ts
@@ -1,53 +1,57 @@
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-};
-var view_1 = require("ui/core/view");
-var dependencyObservable = require("ui/core/dependency-observable");
-var proxy = require("ui/core/proxy");
-var app = require("application");
-var BARSTYLE = "barStyle", STATUSBAR = "StatusBar";
-var BarStyle;
-(function (BarStyle) {
-    BarStyle[BarStyle["default"] = 0] = "default";
-    BarStyle[BarStyle["light"] = 1] = "light";
-    BarStyle[BarStyle["dark"] = 2] = "dark";
-    BarStyle[BarStyle["opaque"] = 3] = "opaque";
-})(BarStyle || (BarStyle = {}));
-var onBarStylePropertyChanged = function (data) {
+import definition = require("statusbar");
+import { View } from "ui/core/view";
+import * as dependencyObservable from "ui/core/dependency-observable";
+import * as proxy from "ui/core/proxy";
+import app = require("application");
+
+let BARSTYLE = "barStyle",
+    STATUSBAR = "StatusBar";
+    
+enum BarStyle {
+    default,
+    light,
+    dark,
+    opaque
+}
+    
+let onBarStylePropertyChanged = (data: dependencyObservable.PropertyChangeData) => {
     try {
-        var statusbar_1 = data.object;
-        var value = data.newValue;
+        let statusbar = <StatusBar>data.object;
+        let value = data.newValue;
+        
         if (app.ios) {
-            setTimeout(function () { statusbar_1.update(BarStyle[value]); });
+            setTimeout(() => { statusbar.update(BarStyle[value]); });
         }
+
         if (app.android) {
-            setTimeout(function () { statusbar_1.update(value); });
+            setTimeout(() => { statusbar.update(value); });
         }
     }
     catch (err) {
         console.log(err);
     }
-};
-var StatusBar = (function (_super) {
-    __extends(StatusBar, _super);
-    function StatusBar(options) {
-        _super.call(this, options);
+}
+
+export class StatusBar extends View implements definition.StatusBar {  
+    
+    public static  barStyleProperty = new dependencyObservable.Property(
+        BARSTYLE,
+        STATUSBAR,
+        new proxy.PropertyMetadata(undefined, dependencyObservable.PropertyMetadataSettings.None, onBarStylePropertyChanged)
+    );
+    
+    constructor(options?: definition.Options) {
+        super(options);
     }
-    StatusBar.prototype.update = function (value) {
-    };
-    Object.defineProperty(StatusBar.prototype, "barStyle", {
-        get: function () {
-            return this._getValue(StatusBar.barStyleProperty);
-        },
-        set: function (value) {
-            this._setValue(StatusBar.barStyleProperty, value);
-        },
-        enumerable: true,
-        configurable: true
-    });
-    StatusBar.barStyleProperty = new dependencyObservable.Property(BARSTYLE, STATUSBAR, new proxy.PropertyMetadata(undefined, dependencyObservable.PropertyMetadataSettings.None, onBarStylePropertyChanged));
-    return StatusBar;
-})(view_1.View);
-exports.StatusBar = StatusBar;
+    
+    public update(value: string) {
+        
+    }
+    
+    get barStyle(): any {
+        return this._getValue(StatusBar.barStyleProperty);
+    }
+    set barStyle(value: any) {
+        this._setValue(StatusBar.barStyleProperty, value);
+    }
+}

--- a/source/statusbar-common.ts
+++ b/source/statusbar-common.ts
@@ -2,6 +2,7 @@ import definition = require("statusbar");
 import { View } from "ui/core/view";
 import * as dependencyObservable from "ui/core/dependency-observable";
 import * as proxy from "ui/core/proxy";
+import app = require("application");
 
 let BARSTYLE = "barStyle",
     STATUSBAR = "StatusBar";
@@ -18,7 +19,13 @@ let onBarStylePropertyChanged = (data: dependencyObservable.PropertyChangeData) 
         let statusbar = <StatusBar>data.object;
         let value = data.newValue;
         
-        setTimeout(() => { statusbar.update(BarStyle[value]); });
+        if (app.ios) {
+            setTimeout(() => { statusbar.update(BarStyle[value]); });
+        }
+
+        if (app.android) {
+            setTimeout(() => { statusbar.update(value); });
+        }
     }
     catch (err) {
         console.log(err);

--- a/source/statusbar.android.js
+++ b/source/statusbar.android.js
@@ -4,6 +4,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var common = require("./statusbar-common");
+var platform = require("platform");
 var app = require("application");
 var color = require("color");
 var StatusBar = (function (_super) {
@@ -13,7 +14,7 @@ var StatusBar = (function (_super) {
     }
     StatusBar.prototype.update = function (value) {
         try {
-            if (value) {
+            if (value && platform.device.sdkVersion >= "21") {
                 var nativeColor = new color.Color(value).android;
                 var window = app.android.startActivity.getWindow();
                 window.setStatusBarColor(nativeColor);

--- a/source/statusbar.android.js
+++ b/source/statusbar.android.js
@@ -4,12 +4,24 @@ var __extends = (this && this.__extends) || function (d, b) {
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var common = require("./statusbar-common");
+var app = require("application");
+var color = require("color");
 var StatusBar = (function (_super) {
     __extends(StatusBar, _super);
     function StatusBar(options) {
         _super.call(this, options);
     }
     StatusBar.prototype.update = function (value) {
+        try {
+            if (value) {
+                var nativeColor = new color.Color(value).android;
+                var window = app.android.startActivity.getWindow();
+                window.setStatusBarColor(nativeColor);
+            }
+        }
+        catch (err) {
+            console.log(err);
+        }
     };
     return StatusBar;
 })(common.StatusBar);

--- a/source/statusbar.android.ts
+++ b/source/statusbar.android.ts
@@ -1,11 +1,20 @@
-// NOT IMPLEMENTED YET
 import common = require("./statusbar-common");
 import definition = require("statusbar");
+import app = require("application");
+import color = require("color");
 
 export class StatusBar extends common.StatusBar {
     
-    public update(value: string) {        
-        // TODO        
+    public update(value: string) {
+        try {
+            if (value) {
+                var nativeColor = new color.Color(value).android;
+                var window = app.android.startActivity.getWindow();
+                window.setStatusBarColor(nativeColor);
+            }        
+        } catch (err) {
+            console.log(err);
+        }        
     }
     
     constructor(options?: definition.Options) {

--- a/source/statusbar.android.ts
+++ b/source/statusbar.android.ts
@@ -1,5 +1,6 @@
 import common = require("./statusbar-common");
 import definition = require("statusbar");
+import platform = require("platform");
 import app = require("application");
 import color = require("color");
 
@@ -7,7 +8,7 @@ export class StatusBar extends common.StatusBar {
     
     public update(value: string) {
         try {
-            if (value) {
+            if (value && platform.device.sdkVersion >= "21") {
                 var nativeColor = new color.Color(value).android;
                 var window = app.android.startActivity.getWindow();
                 window.setStatusBarColor(nativeColor);


### PR DESCRIPTION
Android statusbar color changes. You might want to update the dist/package with the updates. I only updated the actual `/source` files and modified the demos _main-page.xml_ to show the platform specific settings. Just used the NativeScript default to do that, works perfectly :)

*\* Only works on SDK >= 21 - Lollipop. Pre-lollipop, I think it's possible but it's rather complex and it wasn't something enabled by Android then so it's kind of "hacky"
- Need screenshot
- I would include [Material Design Color Spec](https://www.google.com/design/spec/style/color.html) in the README.md for people to understand how you can set the statusbar with your styles/themes.xml also and to give people a good understanding on MD coloring the status bar :)
